### PR TITLE
Fix bug BatchSendUpdate does not work if toggles are empty

### DIFF
--- a/gateways/toggles.go
+++ b/gateways/toggles.go
@@ -61,8 +61,11 @@ func (r *togglesData) Get(ctx context.Context) (*config.Toggles, error) {
 		}
 		return nil, errors.Wrapf(err, "error while getting the entity")
 	}
+	if e.BatchSendUpdatesOwners == "" {
+		return &config.Toggles{}, nil
+	}
 	return &config.Toggles{
-		BatchSendUpdatesOwners: strings.Split(e.BatchSendUpdatesOwners, ","),
+		BatchSendUpdatesOwners: e.BatchSendUpdatesOwnersAsArray(),
 	}, nil
 }
 
@@ -72,4 +75,11 @@ func togglesKey(ctx context.Context, name string) *datastore.Key {
 
 type togglesEntity struct {
 	BatchSendUpdatesOwners string
+}
+
+func (e *togglesEntity) BatchSendUpdatesOwnersAsArray() []string {
+	if e.BatchSendUpdatesOwners == "" {
+		return nil
+	}
+	return strings.Split(e.BatchSendUpdatesOwners, ",")
 }

--- a/gateways/toggles_test.go
+++ b/gateways/toggles_test.go
@@ -16,7 +16,7 @@ func TestNewToggles(t *testing.T) {
 	}
 	defer testerator.SpinDown()
 
-	t.Run("NoDatastore", func(t *testing.T) {
+	t.Run("NoEntity", func(t *testing.T) {
 		toggles := NewToggles()
 		ct, err := toggles.Get(ctx)
 		if err != nil {
@@ -27,7 +27,25 @@ func TestNewToggles(t *testing.T) {
 		}
 	})
 
-	t.Run("FromDatastore", func(t *testing.T) {
+	t.Run("Empty", func(t *testing.T) {
+		toggles := NewToggles()
+		k := togglesKey(ctx, "DEFAULT")
+		if _, err := datastore.Put(ctx, k, &togglesEntity{
+			BatchSendUpdatesOwners: "",
+		}); err != nil {
+			t.Fatalf("error while putting an entity: %s", err)
+		}
+		ct, err := toggles.Get(ctx)
+		if err != nil {
+			t.Fatalf("error while Get: %+v", err)
+		}
+		want := &config.Toggles{}
+		if diff := deep.Equal(want, ct); diff != nil {
+			t.Error(diff)
+		}
+	})
+
+	t.Run("ValidString", func(t *testing.T) {
 		toggles := NewToggles()
 		k := togglesKey(ctx, "DEFAULT")
 		if _, err := datastore.Put(ctx, k, &togglesEntity{


### PR DESCRIPTION
```
2019-03-15 08:59:00.707 JST
GET
200
143 B
332 ms
AppEngine-Google; (+http://code.google.com/appengine)
/internal/updates
 
2019-03-15 08:59:01.037 JST
skip the repository int128/groovy-ssh due to the feature toggle
2019-03-15 08:59:01.037 JST
skip the repository int128/gradle-swagger-generator-plugin due to the feature toggle

(...snip)
```